### PR TITLE
Return register work id from query

### DIFF
--- a/src/modules/data-interaction/database/repositories/registerWork/registerWork.repository.ts
+++ b/src/modules/data-interaction/database/repositories/registerWork/registerWork.repository.ts
@@ -29,9 +29,17 @@ export class RegisterWorkRepository extends BaseRepository<
     });
   }
   async getByWorkRequestId(workRequestId: string): Promise<RegisterWorkEntity> {
-    return this.repository.findOne({
-      where: { workRequest: { id: workRequestId } },
-    });
+    return this.repository
+      .createQueryBuilder('registerWork')
+      .leftJoinAndSelect('registerWork.workRequest', 'workRequest')
+      .leftJoinAndSelect('registerWork.professional', 'professional')
+      .leftJoinAndSelect('workRequest.beneficiary', 'beneficiary')
+      .leftJoinAndSelect('beneficiary.address', 'address')
+      .leftJoinAndSelect('workRequest.contracts', 'contract')
+      .leftJoinAndSelect('workRequest.contractResignedList', 'contractResignedList')
+      .leftJoinAndSelect('workRequest.room', 'room')
+      .where('workRequest.id = :workRequestId', { workRequestId })
+      .getOne();
   }
   async find(): Promise<RegisterWorkEntity[]> {
     return await this.repository.find({


### PR DESCRIPTION
## Summary
- fetch register work data with related entities and expose register_work.id in repository query

## Testing
- `yarn lint` (fails: Invalid endOfLine value)
- `yarn test` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a62c4ac140832fbe2fe742bd2fd9e6